### PR TITLE
fix: Fix db credentials on .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,12 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=SomeRandomString
 
-DB_HOST=localhost
-DB_DATABASE=homestead
-DB_USERNAME=homestead
-DB_PASSWORD=secret
+DB_CONNECTION=pgsql
+DB_HOST=postgres
+DB_PORT=5432
+DB_DATABASE=hotelmanager
+DB_USERNAME=hotelmanager_user
+DB_PASSWORD=hotelmanager_pass
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file


### PR DESCRIPTION
Use db credentials from dev docker environment.