### PR TITLE
fix: Create Customer Company Validation

### DIFF
--- a/app/Http/Requests/CustomerRequest.php
+++ b/app/Http/Requests/CustomerRequest.php
@@ -26,8 +26,9 @@ class CustomerRequest extends FormRequest
         return [
             'name' => 'required',
             'address' => 'required',
-            'cpf' => 'required',
-            'birthday' => 'required',
+            'cpf' => 'required_if:person_type,App\NaturalPerson',
+            'cnpj' => 'required_if:person_type,App\LegalPerson',
+            'birthday' => 'required_if:person_type,App\NaturalPerson',
         ];
     }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -18,7 +18,7 @@ class CustomerTest extends TestCase
         $response->assertSuccessful();
     }
 
-    public function testCreateCustomerWithoutCnpj()
+    public function testCreatePersonCustomer()
     {
         $this->withoutExceptionHandling();
 
@@ -77,7 +77,9 @@ class CustomerTest extends TestCase
             'address' => 'Infantino Street',
         ]);
 
-        $response->assertSessionHasErrors(['cpf' => 'The cpf field is required.']);
+        $response->assertSessionHasErrors([
+            'cpf' => 'The cpf field is required when person type is App\NaturalPerson.'
+        ]);
     }
 
     public function testCustomerBirthdayIsRequired()
@@ -92,6 +94,38 @@ class CustomerTest extends TestCase
             'address' => 'Infantino Street',
         ]);
 
-        $response->assertSessionHasErrors(['birthday' => 'The birthday field is required.']);
+        $response->assertSessionHasErrors([
+            'birthday' => 'The birthday field is required when person type is App\NaturalPerson.',
+        ]);
+    }
+
+    public function testCreateCompanyCustomer()
+    {
+        $this->withoutExceptionHandling();
+
+        $response = $this->post('customers', [
+            'person_type' => 'App\\LegalPerson',
+            'name' => 'Acme Ltda.',
+            'address' => 'Infantino Street',
+            'cnpj' => '46777333000122',
+            'phone' => '(11) 92121-2807',
+        ]);
+
+        $response->assertSessionHas(['message' => 'Cliente cadastrado com sucesso!']);
+    }
+
+    public function testCompanyCustomerRequiresCnpj()
+    {
+        $response = $this->post('customers', [
+            'person_type' => 'App\\LegalPerson',
+            'name' => 'Acme Ltda.',
+            'address' => 'Infantino Street',
+            'cnpj' => '',
+            'phone' => '(11) 92121-2807',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'cnpj' => 'The cnpj field is required when person type is App\LegalPerson.',
+        ]);
     }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -78,7 +78,7 @@ class CustomerTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors([
-            'cpf' => 'The cpf field is required when person type is App\NaturalPerson.'
+            'cpf' => 'The cpf field is required when person type is App\NaturalPerson.',
         ]);
     }
 


### PR DESCRIPTION
It was requiring birthday and cpf for Company customers.
Require cnpj for Legal person customer.